### PR TITLE
fixed zoom limits so they can be one

### DIFF
--- a/ImageViewTouch/src/it/sephiroth/android/library/imagezoom/ImageViewTouchBase.java
+++ b/ImageViewTouch/src/it/sephiroth/android/library/imagezoom/ImageViewTouchBase.java
@@ -458,12 +458,12 @@ public abstract class ImageViewTouchBase extends ImageView implements IDisposabl
 
 			if ( mScaleType == DisplayType.FIT_TO_SCREEN || mScaleType == DisplayType.FIT_IF_BIGGER ) {
 
-				if ( mMinZoom >= 1 ) {
+				if ( mMinZoom > 1 ) {
 					mMinZoomDefined = false;
 					mMinZoom = ZOOM_INVALID;
 				}
 
-				if ( mMaxZoom <= 1 ) {
+				if ( mMaxZoom < 1 ) {
 					mMaxZoomDefined = true;
 					mMaxZoom = ZOOM_INVALID;
 				}


### PR DESCRIPTION
It should be possible to set zoom limits to one, e.g. when you don't want your image to be scalable down. Documentation also says that when `DisplayType` is `FIT_TO_SCREEN`, you have to set `minZoom <= 1` and `maxZoom >= 1`, which includes the one.
