### PR TITLE
fix android-maven-plugin version to 3.6.0 due to install fail

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
             <plugin>
                 <groupId>com.jayway.maven.plugins.android.generation2</groupId>
                 <artifactId>android-maven-plugin</artifactId>
-                <version>3.3.2</version>
+                <version>3.6.0</version>
                 <configuration>
                     <sdk>
                         <platform>${android.platform}</platform>


### PR DESCRIPTION
Version of android-maven-plugin should be fixed to 3.6.0, due to bug:
http://stackoverflow.com/questions/16585099/adt-22-missing-aapt-exe-after-upgrading
