### PR TITLE
Downgrade back to api version 8

### DIFF
--- a/library/AndroidManifest.xml
+++ b/library/AndroidManifest.xml
@@ -4,7 +4,7 @@
     android:versionCode="1"
     android:versionName="1.0.1" >
 
-    <uses-sdk android:minSdkVersion="9" android:targetSdkVersion="19" />
+    <uses-sdk android:minSdkVersion="8" android:targetSdkVersion="19" />
 
     <application/>
 


### PR DESCRIPTION
Is there a need for the version bump?  Reverting to api 8 and running lint does not warn about a newApi.
