### PR TITLE
Fix #canScroll when image.width < view.width

### DIFF
--- a/library/src/main/java/it/sephiroth/android/library/imagezoom/ImageViewTouch.java
+++ b/library/src/main/java/it/sephiroth/android/library/imagezoom/ImageViewTouch.java
@@ -266,6 +266,10 @@ public class ImageViewTouch extends ImageViewTouchBase {
             return false;
         }
 
+        if (bitmapRect.width() < imageViewRect.width()) {
+            return false;
+        }
+
         if (bitmapRect.right >= imageViewRect.right) {
             if (direction < 0) {
                 return Math.abs(bitmapRect.right - imageViewRect.right) > SCROLL_DELTA_THRESHOLD;


### PR DESCRIPTION
This fixes a bug in the #canScroll method where it always returns true (instead of false), when the width of the bitmap is smaller than the width of the ImageViewTouch.

It can be reproduced by creating a ViewPager containing a ImageViewTouch and loading an image that is smaller than the resulting width of the ImageViewTouch.